### PR TITLE
Add styled-components@4.2.0 to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
     "react-scripts": "1.1.4",
-    "redoc": "^2.0.0-alpha.30"
+    "redoc": "^2.0.0-alpha.30",
+    "styled-components": "^4.2.0"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
The current repository has the following error and cannot execute `npm start` correctly.
This PR solves that problem.

```
Module not found: Can't resolve 'styled-components' in 'path\to\create-react-app-redoc\node_modules\redoc\bundles'
```
